### PR TITLE
Remove deprecated aiohttp _copy_cookies

### DIFF
--- a/aiohttp_sse/__init__.py
+++ b/aiohttp_sse/__init__.py
@@ -66,8 +66,6 @@ class EventSourceResponse(StreamResponse):
             close=not self._keep_alive,
             reason=self._reason)
 
-        self._copy_cookies()
-
         # explicitly enabling chunked encoding, since content length
         # usually not known beforehand.
         self._chunked = True


### PR DESCRIPTION
The _copy_cookies function has been deprecated.

http://aiohttp.readthedocs.io/en/v0.14.4/_modules/aiohttp/web.html
vs
http://aiohttp.readthedocs.io/en/v1.2.0/_modules/aiohttp/web.html

This means this module no longer runs against the latest aiohttp